### PR TITLE
fix: zeebe client error and allow running connector with connector-runtime

### DIFF
--- a/src/main/java/io/camunda/connector/message/SendBPMNMessageFunction.java
+++ b/src/main/java/io/camunda/connector/message/SendBPMNMessageFunction.java
@@ -6,6 +6,7 @@ import io.camunda.connector.api.error.ConnectorException;
 import io.camunda.connector.api.outbound.OutboundConnectorContext;
 import io.camunda.connector.api.outbound.OutboundConnectorFunction;
 import io.camunda.connector.cherrytemplate.CherryConnector;
+import io.camunda.connector.message.util.ZeebeClientHelper;
 import io.camunda.zeebe.client.ZeebeClient;
 import io.camunda.zeebe.client.api.command.PublishMessageCommandStep1;
 import io.camunda.zeebe.client.api.response.PublishMessageResponse;
@@ -36,7 +37,11 @@ public class SendBPMNMessageFunction implements OutboundConnectorFunction, Cherr
    * @param zeebeClient zeebe client to connect the server
    */
   public SendBPMNMessageFunction(ZeebeClient zeebeClient) {
-    this.zeebeClient = zeebeClient;
+    this.zeebeClient = ZeebeClientHelper.buildClient();
+  }
+
+  public SendBPMNMessageFunction() {
+    this.zeebeClient = ZeebeClientHelper.buildClient();
   }
 
   @Override

--- a/src/main/java/io/camunda/connector/message/util/ZeebeClientHelper.java
+++ b/src/main/java/io/camunda/connector/message/util/ZeebeClientHelper.java
@@ -1,0 +1,29 @@
+package io.camunda.connector.message.util;
+
+import io.camunda.connector.message.SendBPMNMessageFunction;
+import io.camunda.connector.message.SendBPMNMessageOutput;
+import io.camunda.zeebe.client.ZeebeClient;
+import io.camunda.zeebe.client.ZeebeClientBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ZeebeClientHelper {
+
+  private static final Logger logger = LoggerFactory.getLogger(SendBPMNMessageFunction.class);
+  private static final String GATEWAY_ADDRESS_ENV_VAR = "ZEEBE_CLIENT_BROKER_GATEWAY_ADDRESS";
+
+  public static ZeebeClient buildClient() {
+    String gatewayAddress = System.getenv(GATEWAY_ADDRESS_ENV_VAR);
+    if (gatewayAddress == null || gatewayAddress.isEmpty()) {
+      logger.info("Environment variable [{}] is not set or is empty", GATEWAY_ADDRESS_ENV_VAR);
+      gatewayAddress = "localhost:26500";
+    }
+
+    ZeebeClientBuilder zeebeClientBuilder = ZeebeClient.newClientBuilder()
+            .gatewayAddress(gatewayAddress);
+
+    zeebeClientBuilder.usePlaintext();
+
+    return zeebeClientBuilder.build();
+  }
+}


### PR DESCRIPTION
This PR fixes zeebe client error that appears when running the connector on camunda's connector-runtime.